### PR TITLE
Improve error handling in Invoke-OAIBeta to display OpenAI API error responses

### DIFF
--- a/PSAI.psd1
+++ b/PSAI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PSAI.psm1'
-    ModuleVersion     = '0.4.9'
+    ModuleVersion     = '0.4.10'
     GUID              = '68662d19-a8f1-484f-b1b7-3bf0e8a436df'
     Author            = 'Douglas Finke'
     CompanyName       = 'Doug Finke'


### PR DESCRIPTION
I installed this module today but did not have a billing quota configured at OpenAI.  So I had a few failed attempts trying to understand what was failing as prompts were being echoed back rather than an actual reply from OpenAI.  Had to drop down to irm to see the actual error in the JSON:

Invoke-RestMethod:                                                                                                      
{
  "error": {
    "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
    "type": "insufficient_quota",
    "param": null,
    "code": "insufficient_quota"
  }
}

To hopefully help anyone else who (inadvertently!) might end up in the same situation, this PR improves error handling for OpenAI billing quotas. Previously, if Invoke-RestMethod failed, the original prompt was returned since ErrorDetails.Message was empty.

With these changes, the function falls back to reading the raw HTTP response stream and pulling out the error message from the JSON. Now a user will see more helpful output like:

You exceeded your current quota, please check your plan and billing details.

Also bumped the module version due to the minor change.