### PR TITLE
Added optional OpenAI-Organization header to AzOAI

### DIFF
--- a/PSAI.psd1
+++ b/PSAI.psd1
@@ -1,10 +1,10 @@
 @{
     RootModule        = 'PSAI.psm1'
-    ModuleVersion     = '0.4.11'
+    ModuleVersion     = '0.5.0'
     GUID              = '68662d19-a8f1-484f-b1b7-3bf0e8a436df'
     Author            = 'Douglas Finke'
     CompanyName       = 'Doug Finke'
-    Copyright         = '© 2024 All rights reserved.'
+    Copyright         = '© 2025 All rights reserved.'
 
     Description       = @'
 PSAI brings OpenAI ChatGPT to PowerShell, leveraging advanced AI capabilities in your PowerShell scripts for dynamic, intelligent automation and data processing

--- a/Private/Invoke-OAIBeta.ps1
+++ b/Private/Invoke-OAIBeta.ps1
@@ -58,7 +58,7 @@ function Invoke-OAIBeta {
 
         'AzureOpenAI' {
             $headers['api-key'] = "$($AzOAISecrets.apiKEY)"
-            if($AzOAISecrets.organizationId) {
+            if (-not [string]::IsNullOrEmpty($AzOAISecrets.organizationId)) {
                 $headers['OpenAI-Organization'] = "$($AzOAISecrets.organizationId)"
             }
             else {

--- a/Private/Invoke-OAIBeta.ps1
+++ b/Private/Invoke-OAIBeta.ps1
@@ -58,6 +58,12 @@ function Invoke-OAIBeta {
 
         'AzureOpenAI' {
             $headers['api-key'] = "$($AzOAISecrets.apiKEY)"
+            if($AzOAISecrets.organizationId) {
+                $headers['OpenAI-Organization'] = "$($AzOAISecrets.organizationId)"
+            }
+            else {
+                $headers.Remove('OpenAI-Organization')
+            }
             
             if ($Body -isnot [System.IO.Stream]) {
                 if ($null -ne $Body -and $Body.Contains("model") ) {

--- a/Public/Set-AzOAISecrets.ps1
+++ b/Public/Set-AzOAISecrets.ps1
@@ -12,15 +12,20 @@ The URI of the Azure OAI.
 The API key for accessing the Azure OAI.
 
 .PARAMETER apiVersion
-The version of the Azure OAI.
+The version of the Azure OAI in YYYY-MM-DD format.
 
 .PARAMETER deploymentName
-The name of the deployment.
+The name of the AI model deployment.
+
+.PARAMETER organizationId
+The organization ID associated with the Azure OAI. This parameter is optional.
 
 .EXAMPLE
-Set-AzOAISecrets -apiURI "https://api.example.com" -apiKEY "myApiKey" -apiVersion "v1" -deploymentName "MyDeployment"
+Set-AzOAISecrets -apiURI "https://api.example.com" -apiKEY "myApiKey" -apiVersion "2024-10-21" -deploymentName "MyDeployment"
 Sets the Azure OAI secrets with the specified values.
 
+.NOTES
+See https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference for more information on Azure OpenAI API version
 #>
 
 function Set-AzOAISecrets {
@@ -33,11 +38,14 @@ function Set-AzOAISecrets {
         [Parameter(Mandatory)]
         $apiVersion,
         [Parameter(Mandatory)]
-        $deploymentName
+        $deploymentName,
+        [Parameter(Mandatory=$false)]
+        $organizationId = $null
     )
 
     $script:AzOAISecrets['apiURI'] = $apiURI
     $script:AzOAISecrets['apiKEY'] = $apiKEY
     $script:AzOAISecrets['apiVersion'] = $apiVersion
     $script:AzOAISecrets['deploymentName'] = $deploymentName
+    $script:AzOAISecrets['organizationId'] = $organizationId
 }

--- a/Public/Set-AzOAISecrets.ps1
+++ b/Public/Set-AzOAISecrets.ps1
@@ -39,7 +39,8 @@ function Set-AzOAISecrets {
         $apiVersion,
         [Parameter(Mandatory)]
         $deploymentName,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
         $organizationId = $null
     )
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ Then set `$env:OpenAIKey` to your key.
 
 After creating an [Azure OpenAI resource](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal), you can use the `PSAI` module to interact with it. 
 
-You need to get the following secrets form the Azure Portal and Azure AI Studio - `apiURI`,`apiVersion`,`apiKey`,`deploymentName`.
+
+You need to get the following secrets from the Azure Portal and Azure AI Studio:
+- `apiURI`
+- `apiVersion`
+- `apiKey`
+- `deploymentName`
+- *(Optional)* `organizationId` (if your Azure OpenAI resource requires the `OpenAI-Organization` header)
 
 ```powershell
 $secrets = @{
@@ -67,11 +73,14 @@ $secrets = @{
     apiKey         = "<Your Azure OpenAI API Key>"
     apiVersion     = "<Your Azure OpenAI API Version>"
     deploymentName = "<Your Azure OpenAI Deployment Name>"
+    organizationId = "<Your Organization ID>" # Optional
 }
 
 Set-OAIProvider AzureOpenAI
 Set-AzOAISecrets @secrets
 ```
+
+If your Azure OpenAI implementation requires the `OpenAI-Organization` header, provide the `organizationId` value. Otherwise, you can omit it.
 
 ## Usage
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## v0.4.12
+
+Thank you to https://github.com/jmkloz for the PR!
+
+- Added optional `organizationId` parameter to `Set-AzOAISecrets` for Azure OpenAI support
+- `Invoke-OAIBeta` now sets the `OpenAI-Organization` header when `organizationId` is provided
 
 ## v0.4.11
 


### PR DESCRIPTION
Some organizations that use the Azure OpenAI implementation require the OpenAI-Organization header to be set. This change allows for this optional field to be set. 